### PR TITLE
Dev

### DIFF
--- a/.github/workflows/jax_tests.yml
+++ b/.github/workflows/jax_tests.yml
@@ -14,7 +14,11 @@ jobs:
       fail-fast: false
       matrix:
         python-version: ["3.11", "3.12"]
-        jax-version: ["0.7.2", "0.8.3", "0.9.2", "0.10.2"]
+        jax-version: ["0.7.2", "0.8.3", "0.9.2", "0.10.2", "0.11.0"]
+        exclude:
+          # JAX 0.11 requires Python >= 3.12
+          - python-version: "3.11"
+            jax-version: "0.11.0"
 
     steps:
     - uses: actions/checkout@v4

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,0 +1,34 @@
+name: Lint
+
+on:
+  push:
+  pull_request:
+    branches: [ "main" ]
+
+jobs:
+  ruff:
+    name: "Ruff"
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v4
+
+    - name: Set up Python
+      uses: actions/setup-python@v5
+      with:
+        python-version: "3.12"
+        cache: 'pip'
+
+    - name: Install ruff
+      run: |
+        # Pinned so a new ruff release cannot break unrelated PRs
+        python -m pip install --upgrade pip
+        python -m pip install ruff==0.15.14
+
+    - name: Lint
+      run: |
+        ruff check --output-format github .
+
+    - name: Format
+      run: |
+        ruff format --check .

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,39 @@ version carries breaking changes.
 
 ## [Unreleased]
 
+## [0.3.1] - 2026-07-28
+
+### Added
+- Support for JAX 0.11, which replaced `scan`'s `num_consts`/`num_carry` parameters with the
+  `ft_in`/`ft_out` FlatTrees. `spool` now extends `ft_out` alongside the log outputs it appends to
+  a scan; without it every spooled `scan` failed on 0.11. JAX 0.11 requires Python 3.12, so the CI
+  matrix pairs it with 3.12 only.
+- Tests covering `spool` of a `scan` under `grad`, `vmap`, `cond`, nesting, and a non-trivial `ys`
+  pytree — combinations that were previously untested on every JAX version.
+
+### Fixed
+- `lox.save(..., key=...)` with a batched key wrote the full, unsharded data into *every* per-key
+  folder instead of that key's shard: the inner `save_data` took its payload as `v` but iterated
+  the enclosing `data`, so its argument was ignored.
+- `lox.save`/`lox.load` could silently mix unrelated runs. Folder names came from concatenating
+  the key's raw words as text, so distinct keys collided — raw `[1, 23]` and `[12, 3]` both
+  produced `123`. Words are now packed into separate 32-bit slots, which is a bijection. Keys made
+  with `jax.random.key(n)` still map to `n`, so existing saved data is unaffected.
+- `lox.load` on a path that is not a directory now raises `FileNotFoundError` naming the path,
+  instead of an opaque error from the first file open.
+- `lox.save` creates its target directory instead of failing when it does not exist.
+- Paths are built with `os.path.join` rather than string concatenation.
+- `ConsoleLogger` no longer swallows `KeyboardInterrupt`/`SystemExit` while rendering: the guard
+  around log stacking caught bare exceptions, so Ctrl-C during a live display could be discarded.
+
+### Changed
+- `argnames` in `lox.load` accepts a bare string as a single name, matching the handling that
+  `spool`/`tap`/`strip`/`keep` gained in 0.3.0.
+- `MultiLogger.callback` raises instead of silently dropping loggers when it is handed a state
+  whose logger count does not match its own.
+- Tooling: `ruff` replaces `black` and `isort` for linting and formatting, and CI now enforces
+  `ruff check`/`ruff format` on every branch.
+
 ## [0.3.0] - 2026-07-09
 
 ### Added

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -30,11 +30,11 @@ pytest tests
 ```
 
 ### 3. Code Quality
-We use `black` and `isort` for formatting. Please run them before committing.
+We use `ruff` for linting and formatting. Please run it before committing.
 
 ```bash
-black .
-isort .
+ruff check --fix .
+ruff format .
 ```
 
 ## Pull Request Process

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 [![PyPI version](https://img.shields.io/badge/pypi-not_available-red.svg)](#installation)
 [![License: Apache-2.0](https://img.shields.io/github/license/huterguier/lox?color=yellow)](https://www.apache.org/licenses/LICENSE-2.0)
 [![Documentation](https://img.shields.io/badge/docs-available-blue.svg)](https://jax-lox.readthedocs.io/en/latest/)
-[![Code Style: Black](https://img.shields.io/badge/codestyle-black-black.svg)](https://black.readthedocs.io/en/stable/the_black_code_style/current_style.html)
+[![Code Style: Ruff](https://img.shields.io/badge/codestyle-ruff-261230.svg)](https://docs.astral.sh/ruff/formatter/)
 
 
 [`lox`](https://github.com/huterguier/lox) is a lightweight and flexible logging library for [JAX](https://github.com/jax-ml/jax).

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -55,7 +55,7 @@ autodoc_default_options = {
 }
 
 
-def string_role(name, rawtext, text, lineno, inliner, options={}, content=[]):
+def string_role(name, rawtext, text, lineno, inliner, options=None, content=None):
     node = nodes.raw(
         "",
         f'<code class="docutils highlight-default literal notranslate"><span class="highlight"><span class="s2">"{text}"</span></span></code>',

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -7,57 +7,61 @@
 # https://www.sphinx-doc.org/en/master/usage/configuration.html#project-information
 import os
 import sys
-from docutils.parsers.rst import roles
+
 from docutils import nodes
+from docutils.parsers.rst import roles
 
-sys.path.insert(0, os.path.abspath('..'))
+sys.path.insert(0, os.path.abspath(".."))
 
-project = 'Lox'
-copyright = '2025, huterguier'
-author = 'huterguier'
+project = "Lox"
+copyright = "2025, huterguier"
+author = "huterguier"
 
 # -- General configuration ---------------------------------------------------
 # https://www.sphinx-doc.org/en/master/usage/configuration.html#general-configuration
 
 extensions = []
 
-templates_path = ['_templates']
-exclude_patterns = ['_build', 'Thumbs.db', '.DS_Store']
-
+templates_path = ["_templates"]
+exclude_patterns = ["_build", "Thumbs.db", ".DS_Store"]
 
 
 # -- Options for HTML output -------------------------------------------------
 # https://www.sphinx-doc.org/en/master/usage/configuration.html#options-for-html-output
 
-html_logo = '_static/lox.png'
-html_favicon = '_static/favicon.png'
+html_logo = "_static/lox.png"
+html_favicon = "_static/favicon.png"
 
-html_theme = 'sphinx_book_theme'
-html_static_path = ['_static']
+html_theme = "sphinx_book_theme"
+html_static_path = ["_static"]
 html_css_files = [
-    'style.css',
+    "style.css",
 ]
 
 extensions = [
-    'sphinx.ext.autodoc',
-    'sphinx.ext.napoleon',       # for Google/Numpy docstrings
-    'sphinx.ext.autosummary',  # for generating summary tables
-    'sphinx_autodoc_typehints',  # for type hints
-    'myst_nb',
+    "sphinx.ext.autodoc",
+    "sphinx.ext.napoleon",  # for Google/Numpy docstrings
+    "sphinx.ext.autosummary",  # for generating summary tables
+    "sphinx_autodoc_typehints",  # for type hints
+    "myst_nb",
 ]
 
 autosummary_generate = True
 
 autodoc_default_options = {
-    'members': True,
-    'undoc-members': True,
-    'show-inheritance': True,
+    "members": True,
+    "undoc-members": True,
+    "show-inheritance": True,
 }
+
 
 def string_role(name, rawtext, text, lineno, inliner, options={}, content=[]):
     node = nodes.raw(
-        '', 
-        f'<code class="docutils highlight-default literal notranslate"><span class="highlight"><span class="s2">"{text}"</span></span></code>', format='html')
+        "",
+        f'<code class="docutils highlight-default literal notranslate"><span class="highlight"><span class="s2">"{text}"</span></span></code>',
+        format="html",
+    )
     return [node], []
 
-roles.register_canonical_role('string', string_role)
+
+roles.register_canonical_role("string", string_role)

--- a/lox/io.py
+++ b/lox/io.py
@@ -68,7 +68,10 @@ def save_callback(
                 lambda x: x.reshape(len(keys), *x.shape[len(key.shape) :]), data
             )
             leaves, treedef = jax.tree.flatten(data_flat)
-            datas = [treedef.unflatten(leaf_tuple) for leaf_tuple in zip(*leaves)]
+            datas = [
+                treedef.unflatten(leaf_tuple)
+                for leaf_tuple in zip(*leaves, strict=True)
+            ]
             for i, data in enumerate(datas):
                 path_i = get_path(path, keys[i])
                 save_data(path_i, data)

--- a/lox/io.py
+++ b/lox/io.py
@@ -39,9 +39,10 @@ def save_callback(
         with open(file, "wb") as f:
             pickle.dump(v, f)
 
-    def save_data(path, v):
+    def save_data(path, data):
+        os.makedirs(path, exist_ok=True)
         for k, v in data.items():
-            file = path + f"/{k}.pkl"
+            file = os.path.join(path, f"{k}.pkl")
             dir, _ = os.path.split(file)
             if not os.path.exists(dir):
                 os.makedirs(dir)
@@ -67,9 +68,9 @@ def save_callback(
             )
             leaves, treedef = jax.tree.flatten(data_flat)
             datas = [treedef.unflatten(leaf_tuple) for leaf_tuple in zip(*leaves)]
-            for k, data in enumerate(datas):
-                path_k = get_path(path, keys[k])
-                save_data(path_k, data)
+            for i, data in enumerate(datas):
+                path_i = get_path(path, keys[i])
+                save_data(path_i, data)
         else:
             path = get_path(path, key)
             save_data(path, data)
@@ -98,10 +99,15 @@ def save(
 
 def load_callback(
     path: StringArray | str,
-    argnames: Optional[Iterable[str]] = None,
+    argnames: Optional[str | Iterable[str]] = None,
     key: Optional[Key] = None,
 ) -> dict[str, Any]:
+    if isinstance(argnames, str):
+        argnames = (argnames,)
+
     def load_data(path):
+        if not os.path.isdir(path):
+            raise FileNotFoundError(f"No such directory: {path!r}")
         data = {}
         if argnames is None:
             for root, _, files in os.walk(path):
@@ -110,12 +116,12 @@ def load_callback(
                     filename = os.path.normpath(os.path.join(dir, file))
                     if filename.endswith(".pkl"):
                         argname = filename[:-4]
-                        file_path = path + f"/{filename}"
+                        file_path = os.path.join(path, filename)
                         with open(file_path, "rb") as f:
                             data[argname] = pickle.load(f)
         else:
             for argname in argnames:
-                file_path = path + f"/{argname}.pkl"
+                file_path = os.path.join(path, f"{argname}.pkl")
                 with open(file_path, "rb") as f:
                     data[argname] = pickle.load(f)
         return data
@@ -144,7 +150,7 @@ def load(
     path: StringArray | str,
     key: Optional[Key] = None,
     result_shape_dtypes: Any = None,
-    argnames: Optional[Iterable[str]] = None,
+    argnames: Optional[str | Iterable[str]] = None,
 ) -> dict[str, Any]:
     """
     Load data from a specified path. Each file in the directory is loaded into a dictionary with the filename (without extension) as the key.
@@ -152,7 +158,7 @@ def load(
     Args:
       path (StringArray): The path from which the data will be loaded.
       result_shape_dtypes (Any, optional): The expected shape and dtype of the loaded data.
-      argnames (Iterable[str], optional): Specific argument names to load. If None, all files in the directory are loaded.
+      argnames (str | Iterable[str], optional): Specific argument name(s) to load. If None, all files in the directory are loaded.
       key (jax.Array, optional): An optional key to differentiate data when loading.
     Returns:
         dict[str, Any]: The loaded data.

--- a/lox/io.py
+++ b/lox/io.py
@@ -1,7 +1,8 @@
 import os
 import pickle
+from collections.abc import Iterable
 from functools import partial
-from typing import Any, Iterable, Optional
+from typing import Any
 
 import jax
 import jax.experimental
@@ -16,7 +17,7 @@ def save_callback(
     data: dict[str, Any],
     path: StringArray | str,
     mode: str = "a",
-    key: Optional[Key] = None,
+    key: Key | None = None,
 ):
     def append(file, v):
         with open(file, "rb") as f:
@@ -82,7 +83,7 @@ def save(
     data: dict[str, Any],
     path: StringArray | str,
     mode: str = "a",
-    key: Optional[jax.Array] = None,
+    key: jax.Array | None = None,
 ):
     """
     Save data to a specified path using a callback function. Each entry in the data dictionary is saved as a separate file with the key as the filename.
@@ -99,8 +100,8 @@ def save(
 
 def load_callback(
     path: StringArray | str,
-    argnames: Optional[str | Iterable[str]] = None,
-    key: Optional[Key] = None,
+    argnames: str | Iterable[str] | None = None,
+    key: Key | None = None,
 ) -> dict[str, Any]:
     if isinstance(argnames, str):
         argnames = (argnames,)
@@ -148,9 +149,9 @@ def load_callback(
 
 def load(
     path: StringArray | str,
-    key: Optional[Key] = None,
+    key: Key | None = None,
     result_shape_dtypes: Any = None,
-    argnames: Optional[str | Iterable[str]] = None,
+    argnames: str | Iterable[str] | None = None,
 ) -> dict[str, Any]:
     """
     Load data from a specified path. Each file in the directory is loaded into a dictionary with the filename (without extension) as the key.

--- a/lox/keeping.py
+++ b/lox/keeping.py
@@ -1,5 +1,5 @@
 import functools
-from typing import Callable, Hashable, Iterable
+from collections.abc import Callable, Hashable, Iterable
 
 import jax
 import jax._src.ad_checkpoint
@@ -80,7 +80,9 @@ def keep(
         new_jaxpr = keep_jaxpr(closed_jaxpr.jaxpr, argnames=argnames, tags=tags)
         closed_jaxpr = ClosedJaxpr(new_jaxpr, closed_jaxpr.consts)
         dynamic_args_flat = tuple(arg for arg in args_flat if not is_hashable(arg))
-        out_flat = jax.core.eval_jaxpr(closed_jaxpr.jaxpr, closed_jaxpr.literals, *dynamic_args_flat)
+        out_flat = jax.core.eval_jaxpr(
+            closed_jaxpr.jaxpr, closed_jaxpr.literals, *dynamic_args_flat
+        )
         out = jax.tree_util.tree_unflatten(
             jax.tree_util.tree_structure(out_shape), out_flat
         )
@@ -105,40 +107,84 @@ def keep_jaxpr(
             logs_in = logs_in.filter(lambda k, _: k in to_keep)
             logs_out = logs_out.filter(lambda k, _: k in to_keep)
             new_invars, new_structure = jax.tree.flatten(logs_in)
-            new_eqns.append(eqn.replace(
-                invars=new_invars,
-                outvars=jax.tree.leaves(logs_out),
-                params={**eqn.params, "structure": new_structure},
-            ))
+            new_eqns.append(
+                eqn.replace(
+                    invars=new_invars,
+                    outvars=jax.tree.leaves(logs_out),
+                    params={**eqn.params, "structure": new_structure},
+                )
+            )
         elif eqn.primitive == jax.extend.core.primitives.scan_p:
             c = eqn.params["jaxpr"]
-            new_eqns.append(eqn.replace(params={**eqn.params,
-                "jaxpr": ClosedJaxpr(keep_jaxpr(c.jaxpr, argnames, tags), c.consts),
-            }))
+            new_eqns.append(
+                eqn.replace(
+                    params={
+                        **eqn.params,
+                        "jaxpr": ClosedJaxpr(
+                            keep_jaxpr(c.jaxpr, argnames, tags), c.consts
+                        ),
+                    }
+                )
+            )
         elif eqn.primitive == jax.extend.core.primitives.cond_p:
-            new_eqns.append(eqn.replace(params={**eqn.params, "branches": tuple(
-                ClosedJaxpr(keep_jaxpr(b.jaxpr, argnames, tags), b.consts)
-                for b in eqn.params["branches"]
-            )}))
+            new_eqns.append(
+                eqn.replace(
+                    params={
+                        **eqn.params,
+                        "branches": tuple(
+                            ClosedJaxpr(keep_jaxpr(b.jaxpr, argnames, tags), b.consts)
+                            for b in eqn.params["branches"]
+                        ),
+                    }
+                )
+            )
         elif eqn.primitive == jax.extend.core.primitives.while_p:
             c, b = eqn.params["cond_jaxpr"], eqn.params["body_jaxpr"]
-            new_eqns.append(eqn.replace(params={**eqn.params,
-                "cond_jaxpr": ClosedJaxpr(keep_jaxpr(c.jaxpr, argnames, tags), c.consts),
-                "body_jaxpr": ClosedJaxpr(keep_jaxpr(b.jaxpr, argnames, tags), b.consts),
-            }))
+            new_eqns.append(
+                eqn.replace(
+                    params={
+                        **eqn.params,
+                        "cond_jaxpr": ClosedJaxpr(
+                            keep_jaxpr(c.jaxpr, argnames, tags), c.consts
+                        ),
+                        "body_jaxpr": ClosedJaxpr(
+                            keep_jaxpr(b.jaxpr, argnames, tags), b.consts
+                        ),
+                    }
+                )
+            )
         elif eqn.primitive == jax.extend.core.primitives.jit_p:
             c = eqn.params["jaxpr"]
-            new_eqns.append(eqn.replace(params={**eqn.params,
-                "jaxpr": ClosedJaxpr(keep_jaxpr(c.jaxpr, argnames, tags), c.consts),
-            }))
+            new_eqns.append(
+                eqn.replace(
+                    params={
+                        **eqn.params,
+                        "jaxpr": ClosedJaxpr(
+                            keep_jaxpr(c.jaxpr, argnames, tags), c.consts
+                        ),
+                    }
+                )
+            )
         elif eqn.primitive == jax.extend.core.primitives.call_p:
-            new_eqns.append(eqn.replace(params={**eqn.params,
-                "call_jaxpr": keep_jaxpr(eqn.params["call_jaxpr"], argnames, tags),
-            }))
+            new_eqns.append(
+                eqn.replace(
+                    params={
+                        **eqn.params,
+                        "call_jaxpr": keep_jaxpr(
+                            eqn.params["call_jaxpr"], argnames, tags
+                        ),
+                    }
+                )
+            )
         elif eqn.primitive == jax._src.ad_checkpoint.remat_p:
-            new_eqns.append(eqn.replace(params={**eqn.params,
-                "jaxpr": keep_jaxpr(eqn.params["jaxpr"], argnames, tags),
-            }))
+            new_eqns.append(
+                eqn.replace(
+                    params={
+                        **eqn.params,
+                        "jaxpr": keep_jaxpr(eqn.params["jaxpr"], argnames, tags),
+                    }
+                )
+            )
         else:
             new_eqns.append(eqn)
     return jaxpr.replace(eqns=new_eqns)

--- a/lox/keeping.py
+++ b/lox/keeping.py
@@ -104,8 +104,8 @@ def keep_jaxpr(
             logs_in = jax.tree.unflatten(eqn.params["structure"], eqn.invars)
             logs_out = jax.tree.unflatten(eqn.params["structure"], eqn.outvars)
             to_keep = select_logs(logs_in, eqn.params["tags"], argnames, tags)
-            logs_in = logs_in.filter(lambda k, _: k in to_keep)
-            logs_out = logs_out.filter(lambda k, _: k in to_keep)
+            logs_in = logs_in.filter(lambda k, _, to_keep=to_keep: k in to_keep)
+            logs_out = logs_out.filter(lambda k, _, to_keep=to_keep: k in to_keep)
             new_invars, new_structure = jax.tree.flatten(logs_in)
             new_eqns.append(
                 eqn.replace(

--- a/lox/logdict.py
+++ b/lox/logdict.py
@@ -1,4 +1,5 @@
-from typing import Any, Callable, Optional
+from collections.abc import Callable
+from typing import Any
 
 import jax
 import jax.numpy as jnp
@@ -60,7 +61,10 @@ class logdict(dict[str, Any]):
         """
         if mode == "mean":
             return logdict(
-                {k: jnp.mean(v, keepdims=True) if len(v) > 1 else v for k, v in self.items()}
+                {
+                    k: jnp.mean(v, keepdims=True) if len(v) > 1 else v
+                    for k, v in self.items()
+                }
             )
         if mode == "first":
             return logdict({k: v[:1] for k, v in self.items()})
@@ -70,9 +74,9 @@ class logdict(dict[str, Any]):
 
     def _slice(
         self,
-        start: Optional[int] = None,
-        stop: Optional[int] = None,
-        step: Optional[int] = None,
+        start: int | None = None,
+        stop: int | None = None,
+        step: int | None = None,
     ) -> "logdict":
         return logdict(
             {k: jax.tree.map(lambda x: x[start:stop:step], v) for k, v in self.items()}

--- a/lox/loggers/console_logger.py
+++ b/lox/loggers/console_logger.py
@@ -65,7 +65,7 @@ class ConsoleLogger(Logger[ConsoleLoggerState]):
         )
         try:
             logss = jax.tree.map(lambda *x: jnp.stack(x), *list(self.logss.values()))
-        except:
+        except Exception:
             return
 
         for k, v in logss.items():

--- a/lox/loggers/logger.py
+++ b/lox/loggers/logger.py
@@ -1,7 +1,8 @@
 from abc import ABC, abstractmethod
+from collections.abc import Callable, Iterable
 from dataclasses import dataclass
 from functools import wraps
-from typing import Callable, Generic, Iterable, TypeVar
+from typing import Generic, TypeVar
 
 import jax
 
@@ -21,7 +22,6 @@ LoggerStateT = TypeVar("LoggerStateT", bound=LoggerState)
 
 
 class Logger(Generic[LoggerStateT], ABC):
-
     @abstractmethod
     def init(self, *args, **kwargs) -> LoggerStateT:
         pass

--- a/lox/loggers/multi_logger.py
+++ b/lox/loggers/multi_logger.py
@@ -1,5 +1,5 @@
+from collections.abc import Sequence
 from dataclasses import dataclass
-from typing import Sequence
 
 import jax
 

--- a/lox/loggers/multi_logger.py
+++ b/lox/loggers/multi_logger.py
@@ -26,6 +26,6 @@ class MultiLogger(Logger[MultiLoggerState]):
 
     def callback(self, logger_state: MultiLoggerState, logs: logdict):
         for sub_logger, sub_logger_state in zip(
-            self.loggers, logger_state.logger_states
+            self.loggers, logger_state.logger_states, strict=True
         ):
             sub_logger.callback(sub_logger_state, logs)

--- a/lox/matplotlib/imshow_logger.py
+++ b/lox/matplotlib/imshow_logger.py
@@ -4,7 +4,6 @@ from lox.matplotlib.matplotlib_logger import MatplotlibLogger
 
 
 class ImshowLogger(MatplotlibLogger):
-
     def __init__(self, argname: str):
         self.argname = argname
 

--- a/lox/matplotlib/matplotlib_logger.py
+++ b/lox/matplotlib/matplotlib_logger.py
@@ -1,5 +1,6 @@
+from collections.abc import Callable
 from dataclasses import dataclass
-from typing import Any, Callable
+from typing import Any
 
 import jax
 import jax.experimental

--- a/lox/primitive.py
+++ b/lox/primitive.py
@@ -1,4 +1,5 @@
-from typing import Any, Iterable
+from collections.abc import Iterable
+from typing import Any
 
 import jax
 import jax.numpy as jnp

--- a/lox/spooling.py
+++ b/lox/spooling.py
@@ -209,12 +209,22 @@ def spool_jaxpr(
         )
         logs_scan = jax.tree.map(lambda aval: Var(aval=aval), logs_scan_avals)
 
+        new_params = {
+            **eqn.params,
+            "jaxpr": ClosedJaxpr(new_inner_jaxpr, inner_closed.consts),
+        }
+        if "ft_out" in new_params:
+            from jax._src import flattree as ft
+
+            carry_ft, ys_ft = new_params["ft_out"].elts
+            n_extra = len(jax.tree.leaves(logs_scan))
+            new_params["ft_out"] = ft.FTTuple(
+                carry_ft, ft.FTTuple(ys_ft, ft.nones(n_extra))
+            )
+
         new_eqn = eqn.replace(
             outvars=[*eqn.outvars, *jax.tree.leaves(logs_scan)],
-            params={
-                **eqn.params,
-                "jaxpr": ClosedJaxpr(new_inner_jaxpr, inner_closed.consts),
-            },
+            params=new_params,
         )
 
         def unstack(logs_scan):

--- a/lox/spooling.py
+++ b/lox/spooling.py
@@ -202,7 +202,7 @@ def spool_jaxpr(
         if not logs_jaxpr:
             return eqn, logdict({}), []
 
-        logs_jaxpr_avals = jax.tree_util.tree_map(lambda l: l.aval, logs_jaxpr)
+        logs_jaxpr_avals = jax.tree_util.tree_map(lambda x: x.aval, logs_jaxpr)
         logs_scan_avals = jax.tree_util.tree_map(
             lambda aval: ShapedArray((eqn.params["length"],) + aval.shape, aval.dtype),
             logs_jaxpr_avals,
@@ -219,7 +219,7 @@ def spool_jaxpr(
 
         def unstack(logs_scan):
             return jax.tree.map(
-                lambda l: l.reshape((-1,) + l.shape[2:]),
+                lambda x: x.reshape((-1,) + x.shape[2:]),
                 logs_scan,
             )
 
@@ -324,7 +324,7 @@ def spool_jaxpr(
         )
         if logs_jaxpr:
             logs_eqn = jax.tree.map(
-                lambda l: Var(aval=ShapedArray(l.aval.shape, l.aval.dtype)), logs_jaxpr
+                lambda x: Var(aval=ShapedArray(x.aval.shape, x.aval.dtype)), logs_jaxpr
             )
             const_literals = [
                 Literal(c, jax.core.get_aval(c)) for c in inner_closed.consts
@@ -351,7 +351,7 @@ def spool_jaxpr(
             return eqn, logdict({}), []
 
         logs_eqn = jax.tree.map(
-            lambda l: Var(aval=ShapedArray(l.aval.shape, l.aval.dtype)), logs_call_jaxpr
+            lambda x: Var(aval=ShapedArray(x.aval.shape, x.aval.dtype)), logs_call_jaxpr
         )
         new_eqn = eqn.replace(
             outvars=[*eqn.outvars, *jax.tree_util.tree_leaves(logs_eqn)],
@@ -367,7 +367,7 @@ def spool_jaxpr(
             return eqn, logdict({}), []
 
         logs_eqn = jax.tree.map(
-            lambda l: Var(aval=ShapedArray(l.aval.shape, l.aval.dtype)),
+            lambda x: Var(aval=ShapedArray(x.aval.shape, x.aval.dtype)),
             logs_remat_jaxpr,
         )
         new_eqn = eqn.replace(

--- a/lox/spooling.py
+++ b/lox/spooling.py
@@ -216,11 +216,9 @@ def spool_jaxpr(
         if "ft_out" in new_params:
             from jax._src import flattree as ft
 
-            carry_ft, ys_ft = new_params["ft_out"].elts
+            carry_ft, ys_ft = new_params["ft_out"].unpack()
             n_extra = len(jax.tree.leaves(logs_scan))
-            new_params["ft_out"] = ft.FTTuple(
-                carry_ft, ft.FTTuple(ys_ft, ft.nones(n_extra))
-            )
+            new_params["ft_out"] = ft.pack((carry_ft, (ys_ft, ft.nones(n_extra))))
 
         new_eqn = eqn.replace(
             outvars=[*eqn.outvars, *jax.tree.leaves(logs_scan)],

--- a/lox/spooling.py
+++ b/lox/spooling.py
@@ -1,5 +1,6 @@
+from collections.abc import Callable, Hashable, Iterable
 from functools import wraps
-from typing import Any, Callable, Hashable, Iterable
+from typing import Any
 
 import jax
 import jax._src.ad_checkpoint
@@ -112,7 +113,9 @@ def make_spooled_jaxpr(
             static_argnums=static_argnums,
             return_shape=True,
         )(*args, **kwargs)
-        new_jaxpr, logs = spool_jaxpr(closed_jaxpr.jaxpr, argnames=argnames, tags=tags, unify=unify)
+        new_jaxpr, logs = spool_jaxpr(
+            closed_jaxpr.jaxpr, argnames=argnames, tags=tags, unify=unify
+        )
         closed_jaxpr = ClosedJaxpr(new_jaxpr, closed_jaxpr.consts)
         logs_shape = jax.tree_util.tree_map(
             lambda v: ShapeDtypeStruct(v.aval.shape, v.aval.dtype), logs
@@ -192,7 +195,9 @@ def spool_jaxpr(
 
     def spool_scan_p(eqn: JaxprEqn) -> tuple[JaxprEqn, logdict, list[JaxprEqn]]:
         inner_closed = eqn.params["jaxpr"]
-        new_inner_jaxpr, logs_jaxpr = spool_jaxpr(inner_closed.jaxpr, argnames, tags, unify)
+        new_inner_jaxpr, logs_jaxpr = spool_jaxpr(
+            inner_closed.jaxpr, argnames, tags, unify
+        )
 
         if not logs_jaxpr:
             return eqn, logdict({}), []
@@ -206,7 +211,10 @@ def spool_jaxpr(
 
         new_eqn = eqn.replace(
             outvars=[*eqn.outvars, *jax.tree.leaves(logs_scan)],
-            params={**eqn.params, "jaxpr": ClosedJaxpr(new_inner_jaxpr, inner_closed.consts)},
+            params={
+                **eqn.params,
+                "jaxpr": ClosedJaxpr(new_inner_jaxpr, inner_closed.consts),
+            },
         )
 
         def unstack(logs_scan):
@@ -223,7 +231,9 @@ def spool_jaxpr(
         new_branches = []
         logs_branches = []
         for branch in branches:
-            new_branch_jaxpr, logs_branch = spool_jaxpr(branch.jaxpr, argnames, tags, unify)
+            new_branch_jaxpr, logs_branch = spool_jaxpr(
+                branch.jaxpr, argnames, tags, unify
+            )
             new_branches.append(ClosedJaxpr(new_branch_jaxpr, branch.consts))
             logs_branches.append(logs_branch)
 
@@ -235,7 +245,10 @@ def spool_jaxpr(
         # Shape/dtype mismatches always raise, even with unify=True
         for key in all_keys:
             avals = [lb[key].aval for lb in logs_branches if key in lb]
-            if len(set(a.shape for a in avals)) > 1 or len(set(a.dtype for a in avals)) > 1:
+            if (
+                len(set(a.shape for a in avals)) > 1
+                or len(set(a.dtype for a in avals)) > 1
+            ):
                 raise ValueError(
                     f"Log key '{key}' has mismatched shapes or dtypes across cond branches."
                 )
@@ -264,7 +277,8 @@ def spool_jaxpr(
                     ordered_vars.append(fill_var)
             n_log_leaves = len(jax.tree.leaves(logs_branch))
             func_outvars = (
-                branch.jaxpr.outvars[:-n_log_leaves] if n_log_leaves
+                branch.jaxpr.outvars[:-n_log_leaves]
+                if n_log_leaves
                 else list(branch.jaxpr.outvars)
             )
             new_branch_jaxpr = branch.jaxpr.replace(
@@ -273,13 +287,17 @@ def spool_jaxpr(
             )
             unified_branches.append(ClosedJaxpr(new_branch_jaxpr, branch.consts))
 
-        logs_eqn = logdict({
-            key: Var(aval=ShapedArray(
-                next(lb[key].aval for lb in logs_branches if key in lb).shape,
-                next(lb[key].aval for lb in logs_branches if key in lb).dtype,
-            ))
-            for key in all_keys
-        })
+        logs_eqn = logdict(
+            {
+                key: Var(
+                    aval=ShapedArray(
+                        next(lb[key].aval for lb in logs_branches if key in lb).shape,
+                        next(lb[key].aval for lb in logs_branches if key in lb).dtype,
+                    )
+                )
+                for key in all_keys
+            }
+        )
         new_eqn = eqn.replace(
             outvars=[*eqn.outvars, *jax.tree.leaves(logs_eqn)],
             params={**eqn.params, "branches": tuple(unified_branches)},
@@ -287,8 +305,12 @@ def spool_jaxpr(
         return new_eqn, logs_eqn, []
 
     def spool_while_p(eqn: JaxprEqn) -> tuple[JaxprEqn, logdict, list[JaxprEqn]]:
-        _, logs_cond = spool_jaxpr(eqn.params["cond_jaxpr"].jaxpr, argnames, tags, unify)
-        _, logs_body = spool_jaxpr(eqn.params["body_jaxpr"].jaxpr, argnames, tags, unify)
+        _, logs_cond = spool_jaxpr(
+            eqn.params["cond_jaxpr"].jaxpr, argnames, tags, unify
+        )
+        _, logs_body = spool_jaxpr(
+            eqn.params["body_jaxpr"].jaxpr, argnames, tags, unify
+        )
         if logs_cond or logs_body:
             print(
                 "Warning: Spooling for while loops is not supported due to non-static length."
@@ -297,12 +319,16 @@ def spool_jaxpr(
 
     def spool_jit_p(eqn: JaxprEqn) -> tuple[JaxprEqn, logdict, list[JaxprEqn]]:
         inner_closed = eqn.params["jaxpr"]
-        new_inner_jaxpr, logs_jaxpr = spool_jaxpr(inner_closed.jaxpr, argnames, tags, unify)
+        new_inner_jaxpr, logs_jaxpr = spool_jaxpr(
+            inner_closed.jaxpr, argnames, tags, unify
+        )
         if logs_jaxpr:
             logs_eqn = jax.tree.map(
                 lambda l: Var(aval=ShapedArray(l.aval.shape, l.aval.dtype)), logs_jaxpr
             )
-            const_literals = [Literal(c, jax.core.get_aval(c)) for c in inner_closed.consts]
+            const_literals = [
+                Literal(c, jax.core.get_aval(c)) for c in inner_closed.consts
+            ]
             call_jaxpr = new_inner_jaxpr.replace(
                 constvars=[],
                 invars=[*new_inner_jaxpr.constvars, *new_inner_jaxpr.invars],
@@ -318,7 +344,9 @@ def spool_jaxpr(
             return eqn, logdict({}), []
 
     def spool_call_p(eqn: JaxprEqn) -> tuple[JaxprEqn, logdict, list[JaxprEqn]]:
-        new_call_jaxpr, logs_call_jaxpr = spool_jaxpr(eqn.params["call_jaxpr"], argnames, tags, unify)
+        new_call_jaxpr, logs_call_jaxpr = spool_jaxpr(
+            eqn.params["call_jaxpr"], argnames, tags, unify
+        )
         if not logs_call_jaxpr:
             return eqn, logdict({}), []
 
@@ -332,7 +360,9 @@ def spool_jaxpr(
         return new_eqn, logs_eqn, []
 
     def spool_remat_p(eqn: JaxprEqn) -> tuple[JaxprEqn, logdict, list[JaxprEqn]]:
-        new_remat_jaxpr, logs_remat_jaxpr = spool_jaxpr(eqn.params["jaxpr"], argnames, tags, unify)
+        new_remat_jaxpr, logs_remat_jaxpr = spool_jaxpr(
+            eqn.params["jaxpr"], argnames, tags, unify
+        )
         if not logs_remat_jaxpr:
             return eqn, logdict({}), []
 

--- a/lox/spooling.py
+++ b/lox/spooling.py
@@ -264,7 +264,7 @@ def spool_jaxpr(
         # Rebuild each branch with log outvars in sorted key order,
         # injecting fill equations for any missing keys.
         unified_branches = []
-        for branch, logs_branch in zip(new_branches, logs_branches):
+        for branch, logs_branch in zip(new_branches, logs_branches, strict=True):
             extra_eqns = []
             ordered_vars = []
             for key in all_keys:

--- a/lox/stripping.py
+++ b/lox/stripping.py
@@ -1,5 +1,5 @@
 import functools
-from typing import Callable, Hashable, Iterable
+from collections.abc import Callable, Hashable, Iterable
 
 import jax
 import jax._src.ad_checkpoint
@@ -77,7 +77,9 @@ def strip(
         new_jaxpr = strip_jaxpr(closed_jaxpr.jaxpr, argnames=argnames, tags=tags)
         closed_jaxpr = ClosedJaxpr(new_jaxpr, closed_jaxpr.consts)
         dynamic_args_flat = tuple(arg for arg in args_flat if not is_hashable(arg))
-        out_flat = jax.core.eval_jaxpr(closed_jaxpr.jaxpr, closed_jaxpr.literals, *dynamic_args_flat)
+        out_flat = jax.core.eval_jaxpr(
+            closed_jaxpr.jaxpr, closed_jaxpr.literals, *dynamic_args_flat
+        )
         out = jax.tree_util.tree_unflatten(
             jax.tree_util.tree_structure(out_shape), out_flat
         )
@@ -102,40 +104,84 @@ def strip_jaxpr(
             logs_in = logs_in.filter(lambda k, _: k not in to_strip)
             logs_out = logs_out.filter(lambda k, _: k not in to_strip)
             new_invars, new_structure = jax.tree.flatten(logs_in)
-            new_eqns.append(eqn.replace(
-                invars=new_invars,
-                outvars=jax.tree.leaves(logs_out),
-                params={**eqn.params, "structure": new_structure},
-            ))
+            new_eqns.append(
+                eqn.replace(
+                    invars=new_invars,
+                    outvars=jax.tree.leaves(logs_out),
+                    params={**eqn.params, "structure": new_structure},
+                )
+            )
         elif eqn.primitive == jax.extend.core.primitives.scan_p:
             c = eqn.params["jaxpr"]
-            new_eqns.append(eqn.replace(params={**eqn.params,
-                "jaxpr": ClosedJaxpr(strip_jaxpr(c.jaxpr, argnames, tags), c.consts),
-            }))
+            new_eqns.append(
+                eqn.replace(
+                    params={
+                        **eqn.params,
+                        "jaxpr": ClosedJaxpr(
+                            strip_jaxpr(c.jaxpr, argnames, tags), c.consts
+                        ),
+                    }
+                )
+            )
         elif eqn.primitive == jax.extend.core.primitives.cond_p:
-            new_eqns.append(eqn.replace(params={**eqn.params, "branches": tuple(
-                ClosedJaxpr(strip_jaxpr(b.jaxpr, argnames, tags), b.consts)
-                for b in eqn.params["branches"]
-            )}))
+            new_eqns.append(
+                eqn.replace(
+                    params={
+                        **eqn.params,
+                        "branches": tuple(
+                            ClosedJaxpr(strip_jaxpr(b.jaxpr, argnames, tags), b.consts)
+                            for b in eqn.params["branches"]
+                        ),
+                    }
+                )
+            )
         elif eqn.primitive == jax.extend.core.primitives.while_p:
             c, b = eqn.params["cond_jaxpr"], eqn.params["body_jaxpr"]
-            new_eqns.append(eqn.replace(params={**eqn.params,
-                "cond_jaxpr": ClosedJaxpr(strip_jaxpr(c.jaxpr, argnames, tags), c.consts),
-                "body_jaxpr": ClosedJaxpr(strip_jaxpr(b.jaxpr, argnames, tags), b.consts),
-            }))
+            new_eqns.append(
+                eqn.replace(
+                    params={
+                        **eqn.params,
+                        "cond_jaxpr": ClosedJaxpr(
+                            strip_jaxpr(c.jaxpr, argnames, tags), c.consts
+                        ),
+                        "body_jaxpr": ClosedJaxpr(
+                            strip_jaxpr(b.jaxpr, argnames, tags), b.consts
+                        ),
+                    }
+                )
+            )
         elif eqn.primitive == jax.extend.core.primitives.jit_p:
             c = eqn.params["jaxpr"]
-            new_eqns.append(eqn.replace(params={**eqn.params,
-                "jaxpr": ClosedJaxpr(strip_jaxpr(c.jaxpr, argnames, tags), c.consts),
-            }))
+            new_eqns.append(
+                eqn.replace(
+                    params={
+                        **eqn.params,
+                        "jaxpr": ClosedJaxpr(
+                            strip_jaxpr(c.jaxpr, argnames, tags), c.consts
+                        ),
+                    }
+                )
+            )
         elif eqn.primitive == jax.extend.core.primitives.call_p:
-            new_eqns.append(eqn.replace(params={**eqn.params,
-                "call_jaxpr": strip_jaxpr(eqn.params["call_jaxpr"], argnames, tags),
-            }))
+            new_eqns.append(
+                eqn.replace(
+                    params={
+                        **eqn.params,
+                        "call_jaxpr": strip_jaxpr(
+                            eqn.params["call_jaxpr"], argnames, tags
+                        ),
+                    }
+                )
+            )
         elif eqn.primitive == jax._src.ad_checkpoint.remat_p:
-            new_eqns.append(eqn.replace(params={**eqn.params,
-                "jaxpr": strip_jaxpr(eqn.params["jaxpr"], argnames, tags),
-            }))
+            new_eqns.append(
+                eqn.replace(
+                    params={
+                        **eqn.params,
+                        "jaxpr": strip_jaxpr(eqn.params["jaxpr"], argnames, tags),
+                    }
+                )
+            )
         else:
             new_eqns.append(eqn)
     return jaxpr.replace(eqns=new_eqns)

--- a/lox/stripping.py
+++ b/lox/stripping.py
@@ -101,8 +101,10 @@ def strip_jaxpr(
             logs_in = jax.tree.unflatten(eqn.params["structure"], eqn.invars)
             logs_out = jax.tree.unflatten(eqn.params["structure"], eqn.outvars)
             to_strip = select_logs(logs_in, eqn.params["tags"], argnames, tags)
-            logs_in = logs_in.filter(lambda k, _: k not in to_strip)
-            logs_out = logs_out.filter(lambda k, _: k not in to_strip)
+            logs_in = logs_in.filter(lambda k, _, to_strip=to_strip: k not in to_strip)
+            logs_out = logs_out.filter(
+                lambda k, _, to_strip=to_strip: k not in to_strip
+            )
             new_invars, new_structure = jax.tree.flatten(logs_in)
             new_eqns.append(
                 eqn.replace(

--- a/lox/tapping.py
+++ b/lox/tapping.py
@@ -153,7 +153,7 @@ def tap_jaxpr(
             structure = eqn.params["structure"]
             logs = jax.tree.unflatten(structure, eqn.invars)
             logs = select_logs(logs, eqn.params["tags"], argnames, tags)
-            logs_avals = jax.tree.map(lambda l: l.aval, logs)
+            logs_avals = jax.tree.map(lambda x: x.aval, logs)
             logs_avals_flat, structure_avals = jax.tree.flatten(logs_avals)
             if logs_avals:
                 print_jaxpr = jax.make_jaxpr(

--- a/lox/tapping.py
+++ b/lox/tapping.py
@@ -1,5 +1,6 @@
+from collections.abc import Callable, Hashable, Iterable
 from functools import wraps
-from typing import Any, Callable, Hashable, Iterable
+from typing import Any
 
 import jax
 import jax._src.ad_checkpoint
@@ -93,6 +94,7 @@ def make_tapped_jaxpr(
     Returns:
         Callable[..., ClosedJaxpr | tuple[ClosedJaxpr, Any]]: A wrapped function that returns the jaxpr and logs.
     """
+
     def wrapped(*args, **kwargs):
         closed_jaxpr, out_shape = jax.make_jaxpr(
             fun,
@@ -147,7 +149,6 @@ def tap_jaxpr(
     modified = False
 
     for eqn in jaxpr.eqns:
-
         if eqn.primitive == lox_p:
             structure = eqn.params["structure"]
             logs = jax.tree.unflatten(structure, eqn.invars)
@@ -159,9 +160,11 @@ def tap_jaxpr(
                     wrapped_callback,
                     static_argnums=(0),
                 )(structure_avals, *logs_avals_flat)
-                new_eqns.append(print_jaxpr.jaxpr.eqns[0].replace(
-                    invars=jax.tree.leaves(logs),
-                ))
+                new_eqns.append(
+                    print_jaxpr.jaxpr.eqns[0].replace(
+                        invars=jax.tree.leaves(logs),
+                    )
+                )
                 modified = True
             new_eqns.append(eqn)
 
@@ -169,10 +172,12 @@ def tap_jaxpr(
             c = eqn.params["jaxpr"]
             new_inner, m = tap_jaxpr(c.jaxpr, callback, argnames)
             if m:
-                new_eqns.append(eqn.replace(
-                    primitive=jax.extend.core.primitives.call_p,
-                    params={"call_jaxpr": new_inner},
-                ))
+                new_eqns.append(
+                    eqn.replace(
+                        primitive=jax.extend.core.primitives.call_p,
+                        params={"call_jaxpr": new_inner},
+                    )
+                )
                 modified = True
             else:
                 new_eqns.append(eqn)
@@ -181,9 +186,14 @@ def tap_jaxpr(
             c = eqn.params["jaxpr"]
             new_inner, m = tap_jaxpr(c.jaxpr, callback, argnames)
             modified |= m
-            new_eqns.append(eqn.replace(params={**eqn.params,
-                "jaxpr": ClosedJaxpr(new_inner, c.consts),
-            }))
+            new_eqns.append(
+                eqn.replace(
+                    params={
+                        **eqn.params,
+                        "jaxpr": ClosedJaxpr(new_inner, c.consts),
+                    }
+                )
+            )
 
         elif eqn.primitive == jax.extend.core.primitives.cond_p:
             new_branches = []
@@ -191,33 +201,53 @@ def tap_jaxpr(
                 new_b, m = tap_jaxpr(b.jaxpr, callback, argnames)
                 modified |= m
                 new_branches.append(ClosedJaxpr(new_b, b.consts))
-            new_eqns.append(eqn.replace(params={**eqn.params,
-                "branches": tuple(new_branches),
-            }))
+            new_eqns.append(
+                eqn.replace(
+                    params={
+                        **eqn.params,
+                        "branches": tuple(new_branches),
+                    }
+                )
+            )
 
         elif eqn.primitive == jax.extend.core.primitives.while_p:
             c, b = eqn.params["cond_jaxpr"], eqn.params["body_jaxpr"]
             new_c, mc = tap_jaxpr(c.jaxpr, callback, argnames)
             new_b, mb = tap_jaxpr(b.jaxpr, callback, argnames)
             modified |= mc | mb
-            new_eqns.append(eqn.replace(params={**eqn.params,
-                "cond_jaxpr": ClosedJaxpr(new_c, c.consts),
-                "body_jaxpr": ClosedJaxpr(new_b, b.consts),
-            }))
+            new_eqns.append(
+                eqn.replace(
+                    params={
+                        **eqn.params,
+                        "cond_jaxpr": ClosedJaxpr(new_c, c.consts),
+                        "body_jaxpr": ClosedJaxpr(new_b, b.consts),
+                    }
+                )
+            )
 
         elif eqn.primitive == jax.extend.core.primitives.call_p:
             new_call, m = tap_jaxpr(eqn.params["call_jaxpr"], callback, argnames)
             modified |= m
-            new_eqns.append(eqn.replace(params={**eqn.params,
-                "call_jaxpr": new_call,
-            }))
+            new_eqns.append(
+                eqn.replace(
+                    params={
+                        **eqn.params,
+                        "call_jaxpr": new_call,
+                    }
+                )
+            )
 
         elif eqn.primitive == jax._src.ad_checkpoint.remat_p:
             new_remat, m = tap_jaxpr(eqn.params["jaxpr"], callback, argnames)
             modified |= m
-            new_eqns.append(eqn.replace(params={**eqn.params,
-                "jaxpr": new_remat,
-            }))
+            new_eqns.append(
+                eqn.replace(
+                    params={
+                        **eqn.params,
+                        "jaxpr": new_remat,
+                    }
+                )
+            )
 
         else:
             new_eqns.append(eqn)

--- a/lox/utils/__init__.py
+++ b/lox/utils/__init__.py
@@ -1,3 +1,3 @@
 from lox.utils.misc import flatten, get_path, is_hashable, select_logs
 
-__all__ = ['flatten', 'get_path', 'is_hashable', 'select_logs']
+__all__ = ["flatten", "get_path", "is_hashable", "select_logs"]

--- a/lox/utils/misc.py
+++ b/lox/utils/misc.py
@@ -1,4 +1,5 @@
-from typing import Any, Callable, Iterable, Optional
+from collections.abc import Callable, Iterable
+from typing import Any
 
 import jax
 from jax import Array as Key
@@ -47,8 +48,8 @@ def flatten(fun: Callable, structure: Any) -> Callable:
 def select_logs(
     logs: "logdict",
     eqn_tags: Iterable[str],
-    argnames: Optional[str | Iterable[str]],
-    tags: Optional[str | Iterable[str]],
+    argnames: str | Iterable[str] | None,
+    tags: str | Iterable[str] | None,
 ) -> "logdict":
     """
     Selects the subset of ``logs`` matching ``argnames``/``tags``.

--- a/lox/utils/misc.py
+++ b/lox/utils/misc.py
@@ -82,6 +82,11 @@ def get_path(path: str, key: Key) -> str:
     """
     Constructs a new path by appending a key to an existing path.
 
+    The folder name is derived by packing the key's raw words into a single integer
+    (each word shifted into its own 32-bit slot), which is a bijection -- distinct keys
+    always produce distinct folder names. For simple keys made with ``jax.random.key(n)``
+    (whose raw data is ``[0, n]``), this reduces to exactly ``str(n)``.
+
     Args:
         path (str): The base path.
         key (Key): The key to append to the path.
@@ -89,6 +94,8 @@ def get_path(path: str, key: Key) -> str:
         str: The new constructed path.
     """
     key_data = jax.random.key_data(key)
-    folder_name = str(int(f"{key_data[0]}{key_data[1]}"))
-    path = path + "/" + folder_name
+    combined = 0
+    for x in key_data.flatten():
+        combined = (combined << 32) | int(x)
+    path = path + "/" + str(combined)
     return path

--- a/lox/utils/string_array.py
+++ b/lox/utils/string_array.py
@@ -5,6 +5,8 @@ import jax.numpy as jnp
 
 from lox.utils.typing import Array
 
+DEFAULT_PADDING = jnp.uint8(255)
+
 
 @jax.tree_util.register_dataclass
 @dataclass
@@ -12,7 +14,7 @@ class StringArray:
     chars: Array
     padding: Array
 
-    def __init__(self, chars: Array, padding: Array = jnp.uint8(255)):
+    def __init__(self, chars: Array, padding: Array = DEFAULT_PADDING):
         self.chars = chars
         self.padding = padding
 
@@ -41,7 +43,7 @@ class StringArray:
 
     @classmethod
     def from_str(
-        cls, s: str, length: int = 1024, padding: Array = jnp.uint8(255)
+        cls, s: str, length: int = 1024, padding: Array = DEFAULT_PADDING
     ) -> "StringArray":
         chars = jnp.full((length,), padding, dtype=jax.numpy.uint8)
         for i, c in enumerate(s):

--- a/lox/wandb/core.py
+++ b/lox/wandb/core.py
@@ -75,7 +75,7 @@ def log(run: WandbRun, logs: logdict):
             if leaves:
                 assert all([len(leaf) == len(leaves[0]) for leaf in leaves])
                 for i in range(len(leaves[0])):
-                    data = flatten(jax.tree.map(lambda l: l[i], logs))
+                    data = flatten(jax.tree.map(lambda x: x[i], logs))
                     run.log(data)
 
     jax.debug.callback(callback, ordered=True, id=run.id, logs=logs)

--- a/lox/wandb/core.py
+++ b/lox/wandb/core.py
@@ -75,7 +75,7 @@ def log(run: WandbRun, logs: logdict):
             if leaves:
                 assert all([len(leaf) == len(leaves[0]) for leaf in leaves])
                 for i in range(len(leaves[0])):
-                    data = flatten(jax.tree.map(lambda x: x[i], logs))
+                    data = flatten(jax.tree.map(lambda x, i=i: x[i], logs))
                     run.log(data)
 
     jax.debug.callback(callback, ordered=True, id=run.id, logs=logs)

--- a/lox/wandb/run.py
+++ b/lox/wandb/run.py
@@ -1,7 +1,1 @@
-from dataclasses import dataclass
-
-import jax
-
-from lox.utils.string_array import StringArray
-
 runs_wandb = {}

--- a/lox/wandb/wandb_logger.py
+++ b/lox/wandb/wandb_logger.py
@@ -1,5 +1,5 @@
+from collections.abc import Callable, Sequence
 from dataclasses import dataclass
-from typing import Callable, Optional, Sequence
 
 import jax
 
@@ -36,7 +36,7 @@ class WandbLogger(Logger[WandbLoggerState]):
         self,
         f: Callable,
         logger_state: WandbLoggerState,
-        argnames: Optional[Sequence[str]] = None,
+        argnames: Sequence[str] | None = None,
         prefix: str = "",
     ) -> Callable:
         def callback(logs: logdict):

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -32,8 +32,6 @@ neptune = [
   "neptune-client>=0.18.3",
 ]
 dev = [
-  "black",
-  "isort",
   "ruff",
   "pytest",
   "pytest-cov",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -61,6 +61,14 @@ docs = [
 [project.urls]
 Homepage = "https://github.com/huterguier/lox"
 
+[tool.ruff]
+target-version = "py311"
+line-length = 88
+
+[tool.ruff.lint]
+select = ["E", "F", "I", "W", "UP", "B"]
+ignore = ["E501"]
+
 [tool.setuptools.packages.find]
 include = ["lox", "lox.*"]
 exclude = ["images"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "lox"
-version = "0.3.0"
+version = "0.3.1"
 description = "Logging library for JAX that compatible with transformations such as jit and vmap."
 readme = "README.md"
 requires-python = ">=3.11"

--- a/tests/loggers/test_logger.py
+++ b/tests/loggers/test_logger.py
@@ -14,7 +14,6 @@ functions = [
 
 
 class TestLogger(ABC):
-
     @abstractmethod
     def logger(self) -> Logger:
         pass

--- a/tests/loggers/test_logger.py
+++ b/tests/loggers/test_logger.py
@@ -1,7 +1,8 @@
 from abc import ABC, abstractmethod
 
+import jax
 import pytest
-from functions import *
+from functions import f_add, f_id, f_scan
 
 import lox
 from lox.loggers import Logger

--- a/tests/test_io.py
+++ b/tests/test_io.py
@@ -64,3 +64,27 @@ def test_save_empty_logs(tmp_path):
     save(empty_logs, path)
     loaded_logs = load(path)
     assert loaded_logs == empty_logs, "Loaded logs should be empty dictionary"
+
+
+def test_load_missing_path_raises(tmp_path):
+    path = str(tmp_path / "never_saved")
+    with pytest.raises(FileNotFoundError):
+        load(path)
+
+
+def test_load_argnames_list(tmp_path):
+    path = str(tmp_path / "logs")
+    data = {"carry": jnp.ones(3), "x": jnp.zeros(3)}
+    save(data, path)
+    loaded_logs = load(path, argnames=["carry"])
+    assert set(loaded_logs.keys()) == {"carry"}
+    assert jnp.array_equal(loaded_logs["carry"], data["carry"])
+
+
+def test_load_argnames_bare_string_is_exact_match(tmp_path):
+    path = str(tmp_path / "logs")
+    data = {"carry": jnp.ones(3), "c": jnp.zeros(3)}
+    save(data, path)
+    loaded_logs = load(path, argnames="carry")
+    assert set(loaded_logs.keys()) == {"carry"}
+    assert jnp.array_equal(loaded_logs["carry"], data["carry"])

--- a/tests/test_io.py
+++ b/tests/test_io.py
@@ -25,13 +25,13 @@ def test_save_load(tmp_path, logs):
     for key in logs:
         if isinstance(logs[key], dict):
             for subkey in logs[key]:
-                assert jnp.array_equal(
-                    logs[key][subkey], loaded_logs[key][subkey]
-                ), f"Mismatch in nested key: {key}->{subkey}"
+                assert jnp.array_equal(logs[key][subkey], loaded_logs[key][subkey]), (
+                    f"Mismatch in nested key: {key}->{subkey}"
+                )
         else:
-            assert jnp.array_equal(
-                logs[key], loaded_logs[key]
-            ), f"Mismatch in key: {key}"
+            assert jnp.array_equal(logs[key], loaded_logs[key]), (
+                f"Mismatch in key: {key}"
+            )
 
 
 def test_vmap_save_load(tmp_path, logs):
@@ -44,13 +44,13 @@ def test_vmap_save_load(tmp_path, logs):
     for key in logs:
         if isinstance(logs[key], dict):
             for subkey in logs[key]:
-                assert jnp.array_equal(
-                    logs[key][subkey], loaded_logs[key][subkey]
-                ), f"Mismatch in nested key: {key}->{subkey}"
+                assert jnp.array_equal(logs[key][subkey], loaded_logs[key][subkey]), (
+                    f"Mismatch in nested key: {key}->{subkey}"
+                )
         else:
-            assert jnp.array_equal(
-                logs[key], loaded_logs[key]
-            ), f"Mismatch in key: {key}"
+            assert jnp.array_equal(logs[key], loaded_logs[key]), (
+                f"Mismatch in key: {key}"
+            )
 
 
 def test_save_invalid_path(logs):

--- a/tests/test_io.py
+++ b/tests/test_io.py
@@ -54,7 +54,7 @@ def test_vmap_save_load(tmp_path, logs):
 
 
 def test_save_invalid_path(logs):
-    with pytest.raises(Exception):
+    with pytest.raises(OSError):
         save(logs, "/invalid_path/test_logs.pkl")
 
 

--- a/tests/test_jit_cache.py
+++ b/tests/test_jit_cache.py
@@ -6,9 +6,6 @@ tap_jaxpr, and strip_jaxpr mutated these shared objects in place, corrupting
 the cache and causing errors on subsequent calls.
 """
 
-import contextlib
-import io
-
 import jax
 import jax.numpy as jnp
 

--- a/tests/test_keep.py
+++ b/tests/test_keep.py
@@ -53,9 +53,7 @@ def test_keep_tags():
 
 def test_keep_argnames_and_tags_is_and():
     x = jnp.ones(4)
-    _, logs = lox.spool(
-        lox.keep(_f_ab_train_c_eval, argnames=["a"], tags=["train"])
-    )(x)
+    _, logs = lox.spool(lox.keep(_f_ab_train_c_eval, argnames=["a"], tags=["train"]))(x)
     assert set(logs.keys()) == {"a"}
 
 

--- a/tests/test_logdict.py
+++ b/tests/test_logdict.py
@@ -3,7 +3,6 @@ import jax.numpy as jnp
 import pytest
 
 import lox
-from lox import logdict
 
 
 @pytest.fixture
@@ -12,6 +11,7 @@ def scan_logs():
         def step(carry, x):
             lox.log({"x": x, "carry": carry})
             return carry + x, carry
+
         return jax.lax.scan(step, 0.0, xs)
 
     xs = jnp.arange(10, dtype=float)

--- a/tests/test_spool.py
+++ b/tests/test_spool.py
@@ -30,6 +30,48 @@ functions = [
 ]
 
 
+def f_scan_carry(x):
+    def step(carry, x):
+        carry = carry + x
+        lox.log({"c": carry})
+        return carry, carry
+
+    return jax.lax.scan(step, 0.0, x)[0]
+
+
+def f_scan_pytree(x):
+    def step(carry, x):
+        carry = carry + x
+        lox.log({"c": carry})
+        return carry, {"a": carry, "b": (carry * 2, carry * 3)}
+
+    return jax.lax.scan(step, 0.0, x)
+
+
+def f_scan_cond(x):
+    branch = jax.jit(f_scan_carry)
+    return jax.lax.cond(x.sum() > 0, branch, branch, x)
+
+
+def f_scan_nested(x):
+    def outer(carry, row):
+        inner = f_scan_carry(row)
+        lox.log({"outer": inner})
+        return carry + inner, inner
+
+    return jax.lax.scan(outer, 0.0, x)
+
+
+# scan bodies whose log outputs must survive an enclosing transformation
+scan_functions = [
+    (f_scan_pytree, (4,), {"c": (4,)}),
+    (jax.grad(f_scan_carry), (4,), {"c": (4,)}),
+    (jax.vmap(f_scan_carry), (3, 4), {"c": (12, 1)}),
+    (f_scan_cond, (4,), {"c": (4,)}),
+    (f_scan_nested, (3, 4), {"c": (12,), "outer": (3,)}),
+]
+
+
 @pytest.fixture(params=[0, 1, 2])
 def key(request):
     return jax.random.key(request.param)
@@ -148,3 +190,11 @@ def test_spool_argnames_and_tags_is_and():
     x = jnp.ones(4)
     _, logs = lox.spool(_f_ab_train_c_eval, argnames=["a"], tags=["train"])(x)
     assert set(logs.keys()) == {"a"}
+
+
+@pytest.mark.parametrize("f, shape, expected_shapes", scan_functions)
+def test_spool_scan_variants(f, shape, expected_shapes):
+    x = jnp.ones(shape)
+    y_spooled, logs = lox.spool(f)(x)
+    assert jax.tree.all(jax.tree.map(jnp.allclose, y_spooled, f(x)))
+    assert {k: tuple(v.shape) for k, v in logs.items()} == expected_shapes

--- a/tests/test_spool.py
+++ b/tests/test_spool.py
@@ -4,18 +4,28 @@ import io
 import jax
 import jax.numpy as jnp
 import pytest
-from functions import f_add, f_call, f_cond, f_grad, f_id, f_jit, f_remat, f_scan, f_while
+from functions import (
+    f_add,
+    f_call,
+    f_cond,
+    f_grad,
+    f_id,
+    f_jit,
+    f_remat,
+    f_scan,
+    f_while,
+)
 
 import lox
 
 functions = [
-    (f_id,    {"x"}),
-    (f_add,   {"x", "z"}),
-    (f_scan,  {"carry", "x"}),
-    (f_call,  {"x"}),
-    (f_jit,   {"x"}),
-    (f_cond,  {"branch", "x"}),
-    (f_grad,  {"x"}),
+    (f_id, {"x"}),
+    (f_add, {"x", "z"}),
+    (f_scan, {"carry", "x"}),
+    (f_call, {"x"}),
+    (f_jit, {"x"}),
+    (f_cond, {"branch", "x"}),
+    (f_grad, {"x"}),
     (f_remat, {"x"}),
 ]
 

--- a/tests/test_strip.py
+++ b/tests/test_strip.py
@@ -51,9 +51,9 @@ def test_strip_tags():
 
 def test_strip_argnames_and_tags_is_and():
     x = jnp.ones(4)
-    _, logs = lox.spool(
-        lox.strip(_f_ab_train_c_eval, argnames=["a"], tags=["train"])
-    )(x)
+    _, logs = lox.spool(lox.strip(_f_ab_train_c_eval, argnames=["a"], tags=["train"]))(
+        x
+    )
     # only "a" matches both argnames and tags; "b" is tagged but not named,
     # "c" is named-excluded and not tagged -- neither should be stripped.
     assert set(logs.keys()) == {"b", "c"}


### PR DESCRIPTION
This pull request introduces support for JAX 0.11, fixes several bugs in the `lox.save`/`lox.load` logic, and migrates the codebase and CI tooling from `black`/`isort` to `ruff` for linting and formatting. It also adds new tests and documentation updates, alongside various code quality and typing improvements.

**JAX 0.11 support and testing:**
- Added support for JAX 0.11, updating `spool` to handle the new `ft_in`/`ft_out` FlatTrees in `scan`, and updated the CI matrix to test JAX 0.11 only with Python 3.12. New tests cover `spool` under various transforms and pytrees. (`CHANGELOG.md` [[1]](diffhunk://#diff-107e910e9f2ebfb9a741fa10b2aa7100cc1fc4f5f3aca2dfe78b905cbd73c0d2R1-R34) [[2]](diffhunk://#diff-5274fec072ac0cf488aaa96f6aee69ca903ed74729eac1cb98adbd8a4e8c223fL17-R21)
- Updated the CI workflow to include JAX 0.11 and restrict it to Python 3.12, excluding incompatible combinations. (`.github/workflows/jax_tests.yml` [.github/workflows/jax_tests.ymlL17-R21](diffhunk://#diff-5274fec072ac0cf488aaa96f6aee69ca903ed74729eac1cb98adbd8a4e8c223fL17-R21))

**Bug fixes and improved reliability:**
- Fixed `lox.save(..., key=...)` so that batched keys are saved to the correct per-key folders, preventing data duplication. (`CHANGELOG.md` [[1]](diffhunk://#diff-06572a96a58dc510037d5efa622f9bec8519bc1beab13c9f251e97e657a9d4edR9-R41) `lox/io.py` [[2]](diffhunk://#diff-85d3fbd7cd0dcdae946248eb018b646be28442f36720052eeea1c46ba9eaed81L42-R46) [[3]](diffhunk://#diff-85d3fbd7cd0dcdae946248eb018b646be28442f36720052eeea1c46ba9eaed81L69-R77)
- Ensured `lox.save`/`lox.load` do not mix unrelated runs by making key-to-path mapping bijective, and improved error handling for missing directories. (`CHANGELOG.md` [[1]](diffhunk://#diff-06572a96a58dc510037d5efa622f9bec8519bc1beab13c9f251e97e657a9d4edR9-R41) `lox/io.py` [[2]](diffhunk://#diff-85d3fbd7cd0dcdae946248eb018b646be28442f36720052eeea1c46ba9eaed81L101-R114) [[3]](diffhunk://#diff-85d3fbd7cd0dcdae946248eb018b646be28442f36720052eeea1c46ba9eaed81L113-R128)
- `lox.save` now creates its target directory if it does not exist, and paths use `os.path.join` instead of string concatenation. (`CHANGELOG.md` [[1]](diffhunk://#diff-06572a96a58dc510037d5efa622f9bec8519bc1beab13c9f251e97e657a9d4edR9-R41) `lox/io.py` [[2]](diffhunk://#diff-85d3fbd7cd0dcdae946248eb018b646be28442f36720052eeea1c46ba9eaed81L42-R46)

**Linting, formatting, and code quality:**
- Replaced `black`/`isort` with `ruff` for linting and formatting in CI, documentation, and developer instructions. Added a new `lint.yml` workflow for `ruff`. (`CHANGELOG.md` [[1]](diffhunk://#diff-06572a96a58dc510037d5efa622f9bec8519bc1beab13c9f251e97e657a9d4edR9-R41) `.github/workflows/lint.yml` [[2]](diffhunk://#diff-107e910e9f2ebfb9a741fa10b2aa7100cc1fc4f5f3aca2dfe78b905cbd73c0d2R1-R34) `CONTRIBUTING.md` [[3]](diffhunk://#diff-eca12c0a30e25b4b46522ebf89465a03ba72a03f540796c979137931d8f92055L33-R37) `README.md` [[4]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L9-R9)
- Refactored code for improved typing and imports, using `collections.abc` for `Callable`, `Iterable`, and `Hashable` across multiple files. (`lox/io.py` [[1]](diffhunk://#diff-85d3fbd7cd0dcdae946248eb018b646be28442f36720052eeea1c46ba9eaed81R3-R5) `lox/keeping.py` [[2]](diffhunk://#diff-bbe5153e7240b579ff3e17294cbe4908766073cb5e67fea0b756fef2c6f4db9eL2-R2) `lox/logdict.py` [[3]](diffhunk://#diff-f9afb4987180cde9ccdda41a30cb9857f24d04df286449a59624ed12188da926L1-R2) `lox/loggers/logger.py` [[4]](diffhunk://#diff-fd6192ca11e1c4431d3604def4cc6e512079a201b96a05952aa0202455203cc1R2-R5)
- Updated function signatures and error handling for clarity and correctness, including more precise typing and exception handling. (`lox/io.py` [[1]](diffhunk://#diff-85d3fbd7cd0dcdae946248eb018b646be28442f36720052eeea1c46ba9eaed81L19-R20) [[2]](diffhunk://#diff-85d3fbd7cd0dcdae946248eb018b646be28442f36720052eeea1c46ba9eaed81L84-R89) [[3]](diffhunk://#diff-85d3fbd7cd0dcdae946248eb018b646be28442f36720052eeea1c46ba9eaed81L145-R165) `lox/logdict.py` [[4]](diffhunk://#diff-f9afb4987180cde9ccdda41a30cb9857f24d04df286449a59624ed12188da926L73-R79) `lox/loggers/console_logger.py` [[5]](diffhunk://#diff-98e28296a40cebb498d3da473192f93d459a05e5a4f56a50443ad950b56de10eL68-R68)

**Documentation and style:**
- Updated documentation to reflect the switch to `ruff`, improved Sphinx configuration, and updated badges. (`README.md` [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L9-R9) `CONTRIBUTING.md` [[2]](diffhunk://#diff-eca12c0a30e25b4b46522ebf89465a03ba72a03f540796c979137931d8f92055L33-R37) `docs/conf.py` [[3]](diffhunk://#diff-85933aa74a2d66c3e4dcdf7a9ad8397f5a7971080d34ef1108296a7c6b69e7e3L10-R67)

**Other improvements:**
- Refactored code in `lox/keeping.py` and `lox/logdict.py` for readability and maintainability, including better formatting and use of keyword arguments. (`lox/keeping.py` [[1]](diffhunk://#diff-bbe5153e7240b579ff3e17294cbe4908766073cb5e67fea0b756fef2c6f4db9eL83-R85) [[2]](diffhunk://#diff-bbe5153e7240b579ff3e17294cbe4908766073cb5e67fea0b756fef2c6f4db9eL105-R187) `lox/logdict.py` [[3]](diffhunk://#diff-f9afb4987180cde9ccdda41a30cb9857f24d04df286449a59624ed12188da926L63-R67)

These changes collectively improve compatibility, reliability, and maintainability of the codebase.